### PR TITLE
Fix issues #79, #92, #93, #99, #111, #119, #120

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -105,6 +105,7 @@ Format: `edit INDEX [n/NAME] [g/GROUP1] [g/GROUP2] [p/PHONE] [e/EMAIL] [tg/TELEG
 
 Examples:
 *  `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
+* `find Betsy` followed by `edit 1` edits the 1st person in the results of the `find` command.
 
 ### Locating persons by name: `find`
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -38,7 +38,6 @@ public class AddCommand extends Command {
             + PREFIX_GITHUB + "johndoe ";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
 
     private final Person toAdd;
 
@@ -55,7 +54,7 @@ public class AddCommand extends Command {
         requireNonNull(model);
 
         if (model.hasPerson(toAdd)) {
-            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+            throw new CommandException(model.getSamePersonConstraintMessage(toAdd));
         }
 
         model.addPerson(toAdd);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -55,7 +55,6 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
@@ -102,7 +101,7 @@ public class EditCommand extends Command {
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
         if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
-            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+            throw new CommandException(model.getSamePersonConstraintMessage(editedPerson));
         }
 
         model.setPerson(personToEdit, editedPerson);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -185,11 +185,14 @@ public class ParserUtil {
     public static String parseUsername(String username) throws ParseException {
         requireNonNull(username);
         String trimmedUsername = username.trim();
+        if (trimmedUsername.isEmpty()) {
+            throw new ParseException(Social.MESSAGE_CONSTRAINTS);
+        }
         if (trimmedUsername.charAt(0) == '@') { // removes any prepended '@' if it is present
             trimmedUsername = trimmedUsername.substring(1);
         }
 
-        if (!Social.isValidUsername(trimmedUsername)) {
+        if (trimmedUsername.isEmpty() || !Social.isValidUsername(trimmedUsername)) {
             throw new ParseException(Social.MESSAGE_CONSTRAINTS);
         }
         return trimmedUsername;

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -67,6 +67,16 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Returns the message constraint that comes from {@code person} havng the same equality
+     * (as defined in Person#isSamePerson) with another person in the address book.
+     * PRECONDITION: otherPerson returns false with Person#isSamePerson.
+     */
+    public String getSamePersonConstraintMessage(Person person) {
+        requireNonNull(person);
+        return persons.getSamePersonConstrantMessage(person);
+    }
+
+    /**
      * Adds a person to the address book.
      * The person must not already exist in the address book.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -61,6 +61,14 @@ public interface Model {
     boolean hasPerson(Person person);
 
     /**
+     * Returns the message constraint that comes from {@code person} havng the same equality
+     * (as defined in Person#isSamePerson) with another person in the address book.
+     * PRECONDITION: there is another person in the addressbook that returns true with {@code person} when called by
+     * Person#isSamePerson.
+     */
+    String getSamePersonConstraintMessage(Person person);
+
+    /**
      * Deletes the given person.
      * The person must exist in the address book.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -105,6 +105,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public String getSamePersonConstraintMessage(Person person) {
+        requireNonNull(person);
+        return addressBook.getSamePersonConstraintMessage(person);
+    }
+
+    @Override
     public void deletePerson(Person target) {
         addressBook.removePerson(target);
     }

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -16,7 +16,7 @@ public class Name {
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "^[a-zA-Z\\s]*$";
+    public static final String VALIDATION_REGEX = "[a-zA-Z][a-zA-Z ]*";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -10,13 +10,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Names should only contain alphabetical letters and spaces, and it should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "^[a-zA-Z\\s]*$";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -76,8 +76,8 @@ public class Person {
             return true;
         }
 
-        return otherPerson != null &&
-                (otherPerson.getName().equalsIgnoreCaseAndWhiteSpaces(getName())
+        return otherPerson != null
+                && (otherPerson.getName().equalsIgnoreCaseAndWhiteSpaces(getName())
                 || otherPerson.getPhone().equals(getPhone())
                 || otherPerson.getEmail().value.equalsIgnoreCase(getEmail().value)
                 || otherPerson.getTelegram().username.equalsIgnoreCase(getTelegram().username)
@@ -96,7 +96,7 @@ public class Person {
         }
 
         if (otherPerson.getPhone().equals(getPhone())) {
-           return String.format(MESSAGE_DUPLICATE_PERSON, "phone number", getPhone());
+            return String.format(MESSAGE_DUPLICATE_PERSON, "phone number", getPhone());
         }
 
         if (otherPerson.getEmail().value.equalsIgnoreCase(getEmail().value)) {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -1,5 +1,6 @@
 package seedu.address.model.person;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Collections;
@@ -16,6 +17,8 @@ import seedu.address.model.person.social.Telegram;
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public class Person {
+    public static final String MESSAGE_DUPLICATE_PERSON =
+            "A person with this %s (%s) already exists in the address book.";
 
     // Identity fields
     private final Name name;
@@ -65,16 +68,51 @@ public class Person {
     }
 
     /**
-     * Returns true if both persons have the same name.
-     * This defines a weaker notion of equality between two persons.
+     * Returns true if both persons are the same, defined by
+     * a weaker notion of equality between two persons.
      */
     public boolean isSamePerson(Person otherPerson) {
         if (otherPerson == this) {
             return true;
         }
 
-        return otherPerson != null
-                && otherPerson.getName().equalsIgnoreCaseAndWhiteSpaces(getName());
+        return otherPerson != null &&
+                (otherPerson.getName().equalsIgnoreCaseAndWhiteSpaces(getName())
+                || otherPerson.getPhone().equals(getPhone())
+                || otherPerson.getEmail().value.equalsIgnoreCase(getEmail().value)
+                || otherPerson.getTelegram().username.equalsIgnoreCase(getTelegram().username)
+                || otherPerson.getGitHub().username.equalsIgnoreCase(getGitHub().username));
+    }
+
+    /**
+     * Returns an empty string if both persons are the same, defined by
+     * a weaker notion of equality between two persons. Else, returns the corresponding constraint message.
+     * PRECONDITION: otherPerson returns false with this person, when used with Person#isSamePerson.
+     */
+    public String getSamePersonConstraintMessage(Person otherPerson) {
+        requireNonNull(otherPerson);
+        if (otherPerson.getName().equalsIgnoreCaseAndWhiteSpaces(getName())) {
+            return String.format(MESSAGE_DUPLICATE_PERSON, "name", getName());
+        }
+
+        if (otherPerson.getPhone().equals(getPhone())) {
+           return String.format(MESSAGE_DUPLICATE_PERSON, "phone number", getPhone());
+        }
+
+        if (otherPerson.getEmail().value.equalsIgnoreCase(getEmail().value)) {
+            return String.format(MESSAGE_DUPLICATE_PERSON, "email address", getEmail());
+        }
+
+        if (otherPerson.getTelegram().username.equalsIgnoreCase(getTelegram().username)) {
+            return String.format(MESSAGE_DUPLICATE_PERSON, "telegram username", getTelegram());
+        }
+
+        if (otherPerson.getGitHub().username.equalsIgnoreCase(getGitHub().username)) {
+            return String.format(MESSAGE_DUPLICATE_PERSON, "github username", getGitHub());
+        }
+
+        assert false; // should not reach here due to precondition
+        return "";
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -134,4 +134,20 @@ public class UniquePersonList implements Iterable<Person> {
         }
         return true;
     }
+
+    /**
+     * Returns the message constraint that comes from {@code person} havng the same equality
+     * (as defined in Person#isSamePerson) with another person in the address book.
+     * PRECONDITION: otherPerson returns false with some person in the addressbook as defined by Person#isSamePerson.
+     */
+    public String getSamePersonConstrantMessage(Person otherPerson) {
+        requireNonNull(otherPerson);
+        for (Person p: internalList) {
+            if (p.isSamePerson(otherPerson)) {
+                return p.getSamePersonConstraintMessage(otherPerson);
+            }
+        }
+        assert false; // should not reach here due to precondition
+        return "";
+    }
 }

--- a/src/main/java/seedu/address/model/person/social/Social.java
+++ b/src/main/java/seedu/address/model/person/social/Social.java
@@ -7,8 +7,9 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
  * This class encapsulates a URL to an online profile.
  */
 public abstract class Social {
-    public static final String MESSAGE_CONSTRAINTS = "Username may only contain alphanumeric characters "
-        + "or single hyphens/underscores, and cannot begin or end with a hyphen/underscores.";
+    public static final String MESSAGE_CONSTRAINTS = "Usernames cannot be blank,"
+        + " and may only contain alphanumeric characters or single hyphens/underscores,"
+        + " and cannot begin or end with a hyphen/underscores.";
     // Adapted from https://github.com/regexhq/regex-username
     private static final String VALIDATION_REGEX = "^([a-zA-Z\\d]+[-_])*[a-zA-Z\\d]+$";
     public final String username;

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -40,7 +40,8 @@ public class AddCommandIntegrationTest {
     @Test
     public void execute_duplicatePerson_throwsCommandException() {
         Person personInList = model.getAddressBook().getPersonList().get(0);
-        assertCommandFailure(new AddCommand(personInList), model, AddCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(new AddCommand(personInList), model,
+                String.format(Person.MESSAGE_DUPLICATE_PERSON, "name", personInList.getName()));
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -51,8 +51,8 @@ public class AddCommandTest {
         ModelStub modelStub = new ModelStubWithPerson(validPerson);
 
         assertThrows(CommandException.class,
-                String.format(Person.MESSAGE_DUPLICATE_PERSON, "name", validPerson.getName()),
-                () -> addCommand.execute(modelStub));
+                String.format(Person.MESSAGE_DUPLICATE_PERSON, "name", validPerson.getName()), () ->
+                        addCommand.execute(modelStub));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -50,7 +50,9 @@ public class AddCommandTest {
         AddCommand addCommand = new AddCommand(validPerson);
         ModelStub modelStub = new ModelStubWithPerson(validPerson);
 
-        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_PERSON, () -> addCommand.execute(modelStub));
+        assertThrows(CommandException.class,
+                String.format(Person.MESSAGE_DUPLICATE_PERSON, "name", validPerson.getName()),
+                () -> addCommand.execute(modelStub));
     }
 
     @Test
@@ -128,6 +130,11 @@ public class AddCommandTest {
 
         @Override
         public boolean hasPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public String getSamePersonConstraintMessage(Person person) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -213,6 +220,12 @@ public class AddCommandTest {
             requireNonNull(person);
             return this.person.isSamePerson(person);
         }
+
+        @Override
+        public String getSamePersonConstraintMessage(Person otherPerson) {
+            requireNonNull(person);
+            return person.getSamePersonConstraintMessage(otherPerson);
+        }
     }
 
     /**
@@ -232,6 +245,7 @@ public class AddCommandTest {
             requireNonNull(person);
             personsAdded.add(person);
         }
+
 
         @Override
         public ReadOnlyAddressBook getAddressBook() {

--- a/src/test/java/seedu/address/logic/commands/AddTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTaskCommandTest.java
@@ -98,6 +98,11 @@ public class AddTaskCommandTest {
         }
 
         @Override
+        public String getSamePersonConstraintMessage(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void deletePerson(Person target) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -107,7 +107,8 @@ public class EditCommandTest {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editCommand, model,
+                String.format(Person.MESSAGE_DUPLICATE_PERSON, "name", firstPerson.getName()));
     }
 
     @Test
@@ -119,7 +120,8 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
                 new EditPersonDescriptorBuilder(personInList).build());
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editCommand, model,
+                String.format(Person.MESSAGE_DUPLICATE_PERSON, "name", personInList.getName()));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -32,9 +32,8 @@ public class NameTest {
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
-        assertTrue(Name.isValidName("12345")); // numbers only
-        assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
+        assertTrue(Name.isValidName("peter the second")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
-        assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
+        assertTrue(Name.isValidName("David Roger Jackson Ray Jr Second")); // long names
     }
 }

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -30,9 +30,9 @@ public class PersonTest {
                 .withGroups(VALID_GROUP_BOB).withTelegram(VALID_TELEGRAM_BOB).withGitHub(VALID_GITHUB_BOB).build();
         assertTrue(ALICE.isSamePerson(editedAlice));
 
-        // different name, all other attributes same -> returns false
+        // different name, all phone/email/github/telegram same -> returns true
         editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
-        assertFalse(ALICE.isSamePerson(editedAlice));
+        assertTrue(ALICE.isSamePerson(editedAlice));
 
         // name differs in case, all other attributes same -> returns true
         Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();


### PR DESCRIPTION
Changes:
1. Correct error message shown in GUI when telegram/github username is left blank
2. Person equality is stricter now where a person is equal with another person if their name/phone number/email/telegram/github are the same
3. Names can only have alphabetical letters and spaces (before, it allowed alphanumeric characters)
4. More specific duplicate person message (displays what field is duplicated)
5. Minor UG changes